### PR TITLE
[Feature #162879502] Created and tested get all diary entries endpoint

### DIFF
--- a/controllers/diaryController.js
+++ b/controllers/diaryController.js
@@ -6,6 +6,13 @@ class DiaryController {
       message: 'App is live',
     });
   }
+
+  static getAll(req, res) {
+    res.status(200).json({
+      diaryList,
+      message: 'Diary entries successfully retrieved',
+    });
+  }
 }
 
 export default DiaryController;

--- a/routes/diaryRoute.js
+++ b/routes/diaryRoute.js
@@ -3,4 +3,6 @@ import diaryController from '../controllers/diaryController';
 export default (router) => {
   router.route('/v1/status')
     .get(diaryController.status);
+  router.route('/v1/entries')
+    .get(diaryController.getAll);
 };

--- a/tests/diaryTest.js
+++ b/tests/diaryTest.js
@@ -5,3 +5,15 @@ import chaiHttp from 'chai-http';
 import app from '../index';
 
 chai.use(chaiHttp);
+
+describe("Test diary endpoint at '/v1/entries' to get all entries with GET", () => {
+  it("should get all diary entries at '/v1/entries' with GET", (done) => {
+    chai.request(app)
+      .get('/v1/entries')
+      .then((res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).be.an('object');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
**What does this PR do:**
Get all diary entries

**Description of Task completed:**
Have the following endpoint working:
GET '/v1/entries'

**Testing Method**
After cloning repo, cd into it and run `npm test`, alternatively run `npm start` to start the server at [localhost:3000/v1/entries](url) and use Postman to test endpoint using GET

**Pivotal story**
#162879502
